### PR TITLE
Feature/create merkle tree manual

### DIFF
--- a/packages/user-app/pages/create-merkle-tree-manual.tsx
+++ b/packages/user-app/pages/create-merkle-tree-manual.tsx
@@ -383,11 +383,11 @@ export default function CreateAirdrop() {
   ): Promise<[{ [address: string]: BigNumber }, BigNumber]> => {
     let response = await fetch(
       "/api/token/holders?chainId=" +
-        BigNumber.from(chainId).toString() +
-        "&tokenAddress=" +
-        snapshotTokenAddress +
-        "&blockNumber=" +
-        snapshotBlockNumberValue
+      BigNumber.from(chainId).toString() +
+      "&tokenAddress=" +
+      snapshotTokenAddress +
+      "&blockNumber=" +
+      snapshotBlockNumberValue
     );
     let responseJson = (await response.json()) as holdersResponse;
     responseJson.data.map((data: { address: string; balance: string }) => {
@@ -407,7 +407,7 @@ export default function CreateAirdrop() {
     return [snapshotAmount, ttlSnapshotAmount];
   };
 
-  const useApiForWriteFile = async (airdropAmountList: airdropListData[]) => {
+  const useApiForWrittingFile = async (airdropAmountList: airdropListData[]) => {
     await fetch("/api/merkletree", {
       method: "POST",
       headers: {
@@ -443,18 +443,18 @@ export default function CreateAirdrop() {
     if (snapshotTokenAddress2Value !== "") {
       let response = await fetch(
         "/api/token/decimal?chainId=" +
-          BigNumber.from(chainId).toString() +
-          "&tokenAddress=" +
-          snapshotTokenAddress1Value
+        BigNumber.from(chainId).toString() +
+        "&tokenAddress=" +
+        snapshotTokenAddress1Value
       );
       let responseJson = (await response.json()) as decimalResponse;
       const decimals1 = responseJson.data;
 
       response = await fetch(
         "/api/token/decimal?chainId=" +
-          BigNumber.from(chainId).toString() +
-          "&tokenAddress=" +
-          snapshotTokenAddress2Value
+        BigNumber.from(chainId).toString() +
+        "&tokenAddress=" +
+        snapshotTokenAddress2Value
       );
       responseJson = (await response.json()) as decimalResponse;
       const decimals2 = responseJson.data;

--- a/packages/user-app/pages/create-merkle-tree-manual.tsx
+++ b/packages/user-app/pages/create-merkle-tree-manual.tsx
@@ -191,42 +191,12 @@ export default function CreateAirdrop() {
         {deployReadyFlg ? (
           <Box sx={{ width: 0.7 }}>
             <Stack>
-              <Box sx={{ display: "flex", justifyContent: "center" }}>
+              <Box sx={{ display: "flex", justifyContent: "start" }}>
+
                 <TableContainer
                   sx={{
                     m: 2,
-                    width: 0.4,
-                    height: 500,
-                  }}
-                >
-                  <Table aria-label="simple table" stickyHeader>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell colSpan={2}>Snapshot Amount</TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell>Address</TableCell>
-                        <TableCell align="right">Amount</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {snapshotList.map((elm, index) => (
-                        <TableRow key={index}>
-                          <TableCell component="th" scope="row">
-                            {elm[0]}
-                          </TableCell>
-                          <TableCell align="right">
-                            {elm[1].toString()}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-                <TableContainer
-                  sx={{
-                    m: 2,
-                    width: 0.4,
+                    width: 0.6,
                     height: 500,
                   }}
                 >
@@ -376,96 +346,56 @@ export default function CreateAirdrop() {
     if (chainId == null) {
       return;
     }
-    /*let snapshotAmountDict: { [address: string]: BigNumber } = {};
+    let snapshotAmountDict: { [address: string]: BigNumber } = {};
     let resSnapshotAmount: { [address: string]: BigNumber } = {};
     let airdropAmountList: airdropListData[] = [];
     let ttlSnapshotAmount = BigNumber.from(0);
     let resTtlSnapshotAmount = BigNumber.from(0);
     let ttlAirdropAmount = BigNumber.from(0);
-    let airdropAmount = BigNumber.from(airdropTokenAmountValue);
-    let snapshotTokenCoefficient1 = BigNumber.from(
-      snapshotTokenCoefficient1Value
-    );
-    let snapshotTokenCoefficient2 = BigNumber.from(
-      snapshotTokenCoefficient2Value
-    );
-    if (snapshotTokenAddress2Value !== "") {
-      let response = await fetch(
-        "/api/token/decimal?chainId=" +
-        BigNumber.from(chainId).toString() +
-        "&tokenAddress=" +
-        snapshotTokenAddress1Value
-      );
-      let responseJson = (await response.json()) as decimalResponse;
-      const decimals1 = responseJson.data;
+    //let airdropAmount = BigNumber.from(airdropTokenAmountValue);
 
-      response = await fetch(
-        "/api/token/decimal?chainId=" +
-        BigNumber.from(chainId).toString() +
-        "&tokenAddress=" +
-        snapshotTokenAddress2Value
-      );
-      responseJson = (await response.json()) as decimalResponse;
-      const decimals2 = responseJson.data;
+    let v = airdropAddressAmountListRef?.current;
+    if (v) {
+      v.setCustomValidity("");
+      let ok = v.validity.valid;
+      if (v.value !== "") {
+        let spl = v.value.split(/\r?\n/);
+        spl.forEach(function (elm) {
+          let result: string[] = elm.split(',');
+          snapshotAmountDict[result[0]] = BigNumber.from(result[1]);
+        });
 
-      if (decimals1 > decimals2) {
-        snapshotTokenCoefficient2 = snapshotTokenCoefficient2.mul(
-          BigNumber.from(10).pow(decimals1 - decimals2)
+        let snapshotAmountList = Object.entries(snapshotAmountDict).sort(
+          (p1, p2) => {
+            let p1Key = p1[0];
+            let p2Key = p2[0];
+            if (p1Key < p2Key) {
+              return -1;
+            }
+            if (p1Key > p2Key) {
+              return 1;
+            }
+            return 0;
+          }
         );
-      } else if (decimals2 > decimals1) {
-        snapshotTokenCoefficient1 = snapshotTokenCoefficient1.mul(
-          BigNumber.from(10).pow(decimals2 - decimals1)
-        );
+
+        setSnaphshotList(snapshotAmountList);
+
+        snapshotAmountList.map((elm) => {
+          //let calculatedAmount = airdropAmount.mul(elm[1]).div(ttlSnapshotAmount);
+          ttlAirdropAmount = ttlAirdropAmount.add(elm[1]);
+          airdropAmountList.push({ address: elm[0], amount: elm[1] });
+        });
+
+        setAirdropList(airdropAmountList);
+
+        setTtlAirdropAmount(ttlAirdropAmount.toString());
+
+        //the cese using api
+        //useApiForWrittingFile(airdropAmountList, chainId);
+        setDeployReadyFlg(true);
       }
-
-      [resSnapshotAmount, resTtlSnapshotAmount] = await extractTokenBalance(
-        snapshotAmountDict,
-        ttlSnapshotAmount,
-        snapshotTokenAddress2Value,
-        snapshotTokenCoefficient2
-      );
-      snapshotAmountDict = resSnapshotAmount;
-      ttlSnapshotAmount = resTtlSnapshotAmount;
     }
-
-    [resSnapshotAmount, resTtlSnapshotAmount] = await extractTokenBalance(
-      snapshotAmountDict,
-      ttlSnapshotAmount,
-      snapshotTokenAddress1Value,
-      snapshotTokenCoefficient1
-    );
-    snapshotAmountDict = resSnapshotAmount;
-    ttlSnapshotAmount = resTtlSnapshotAmount;
-
-    let snapshotAmountList = Object.entries(snapshotAmountDict).sort(
-      (p1, p2) => {
-        let p1Key = p1[0];
-        let p2Key = p2[0];
-        if (p1Key < p2Key) {
-          return -1;
-        }
-        if (p1Key > p2Key) {
-          return 1;
-        }
-        return 0;
-      }
-    );
-
-    setSnaphshotList(snapshotAmountList);
-
-    snapshotAmountList.map((elm) => {
-      let calculatedAmount = airdropAmount.mul(elm[1]).div(ttlSnapshotAmount);
-      ttlAirdropAmount = ttlAirdropAmount.add(calculatedAmount);
-      airdropAmountList.push({ address: elm[0], amount: calculatedAmount });
-    });
-
-    setAirdropList(airdropAmountList);
-
-    setTtlAirdropAmount(ttlAirdropAmount.toString());*/
-
-    //the cese using api
-    //useApiForWrittingFile(airdropAmountList, chainId);
-    setDeployReadyFlg(true);
   };
 
   return (
@@ -491,7 +421,7 @@ export default function CreateAirdrop() {
                 <Stack
                   sx={{
                     mt: 1,
-                    width: 0.6,
+                    width: 0.7,
                   }}
                 >
                   <Typography
@@ -516,7 +446,7 @@ export default function CreateAirdrop() {
                     variant="outlined"
                     multiline
                     sx={{
-                      width: 0.5,
+                      width: 0.6,
                     }}
                     defaultValue={airdropAddressAmountListValue}
                     onChange={(e: OnChangeEvent) =>

--- a/packages/user-app/pages/create-merkle-tree-manual.tsx
+++ b/packages/user-app/pages/create-merkle-tree-manual.tsx
@@ -297,13 +297,36 @@ export default function CreateAirdrop() {
       let ok = v.validity.valid;
       if (v.value !== "") {
         let spl = v.value.split(/\r?\n/);
-        //,が文字列に含まれているか判定
-        //含まれていれば,で分割をする
-        //,で分割したものの要素数が2か判定
-        //,で分けたときに前半と後半の文字列がどちらも空文字でないか判定
-        //,で分けたときに前半の文字列がアドレスになっているか判定
-        //,で分けたときに後半の文字列が数値になっているか判定
-        //,で分けたときに後半の文字列が整数か判定
+        for (let i = 0; i < spl.length; i++) {
+          ok &&= spl[i].includes(',');
+          if (ok) {
+            let result: string[] = spl[i].split(',');
+            ok &&= result.length === 2;
+            if (!ok) { errorText = "each line must contain two elements"; break; }
+            ok &&= result[0] !== "" && result[1] !== "";
+            if (!ok) { errorText = "address and/or amount is a blank character"; break; }
+            ok &&= ethers.utils.isAddress(result[0]);
+            if (!ok) { errorText = "address is not valid"; break; }
+            ok &&= !Number.isNaN(result[1]);
+            if (!ok) { errorText = "amount is only number"; break; }
+            ok &&= Number.isInteger(result[1]);
+            if (!ok) { errorText = "amount is only integer"; break; }
+          }
+          else { errorText = "string does not contain a comma"; break; }
+        }
+      }
+      setAirdropAddressAmountListError(!ok);
+      if (!ok) {
+        v.setCustomValidity(errorText);
+      }
+      valid &&= ok;
+    }
+
+    /*if (v) {
+      v.setCustomValidity("");
+      let ok = v.validity.valid;
+      if (v.value !== "") {
+        let spl = v.value.split(/\r?\n/);
         spl.forEach(function (elm) {
           ok &&= elm.includes(',');
           if (ok) {
@@ -327,106 +350,7 @@ export default function CreateAirdrop() {
         v.setCustomValidity(errorText);
       }
       valid &&= ok;
-    }
-    /*let v = airdropAddressAmountListRef?.current;
-    if (v) {
-      v.setCustomValidity("");
-      let ok = v.validity.valid;
-      if (v.value !== "") {
-        let spl = v.value.split(/\r?\n/);
-        spl.forEach(function (elm) {
-          ok &&= elm.includes(',');
-        });
-      }
-      setAirdropAddressAmountListError(!ok);
-      if (!ok) {
-        v.setCustomValidity("string does not contain a comma");
-      }
-      valid &&= ok;
-    }
-    if (valid) {
-      if (v) {
-        v.setCustomValidity("");
-        let ok = v.validity.valid;
-        if (v.value !== "") {
-          let spl = v.value.split(/\r?\n/);
-          spl.forEach(function (elm) {
-            let result: string[] = elm.split(',');
-            ok &&= result.length === 2;
-          });
-        }
-        setAirdropAddressAmountListError(!ok);
-        if (!ok) {
-          v.setCustomValidity("each line must contain two elements");
-        }
-        valid &&= ok;
-      }
-      if (v) {
-        v.setCustomValidity("");
-        let ok = v.validity.valid;
-        if (v.value !== "") {
-          let spl = v.value.split(/\r?\n/);
-          spl.forEach(function (elm) {
-            let result: string[] = elm.split(',');
-            ok &&= result[0] !== "" && result[1] !== "";
-          });
-        }
-        setAirdropAddressAmountListError(!ok);
-        if (!ok) {
-          v.setCustomValidity("address and/or amount is a blank character");
-        }
-        valid &&= ok;
-      }
-      if (v) {
-        v.setCustomValidity("");
-        let ok = v.validity.valid;
-        if (v.value !== "") {
-          let spl = v.value.split(/\r?\n/);
-          spl.forEach(function (elm) {
-            let result: string[] = elm.split(',');
-            ok &&= ethers.utils.isAddress(result[0]);
-          });
-        }
-        setAirdropAddressAmountListError(!ok);
-        if (!ok) {
-          v.setCustomValidity("address is not valid");
-        }
-        valid &&= ok;
-      }
-      if (v) {
-        v.setCustomValidity("");
-        let ok = v.validity.valid;
-        if (v.value !== "") {
-          let spl = v.value.split(/\r?\n/);
-          spl.forEach(function (elm) {
-            let result: string[] = elm.split(',');
-            ok &&= !Number.isNaN(result[1]);
-          });
-        }
-        setAirdropAddressAmountListError(!ok);
-        if (!ok) {
-          v.setCustomValidity("amount is only number");
-        }
-        valid &&= ok;
-      }
-      if (v) {
-        v.setCustomValidity("");
-        let ok = v.validity.valid;
-        if (v.value !== "") {
-          let spl = v.value.split(/\r?\n/);
-          spl.forEach(function (elm) {
-            let result: string[] = elm.split(',');
-            ok &&= Number.isInteger(result[1]);
-          });
-        }
-        setAirdropAddressAmountListError(!ok);
-        if (!ok) {
-          v.setCustomValidity("amount is only integer");
-        }
-        valid &&= ok;
-      }
     }*/
-
     return valid;
   };
 

--- a/packages/user-app/pages/create-merkle-tree-manual.tsx
+++ b/packages/user-app/pages/create-merkle-tree-manual.tsx
@@ -545,202 +545,22 @@ export default function CreateAirdrop() {
                     width: 0.6,
                   }}
                 >
-                  <Grid
-                    container
-                    sx={{
-                      m: 2,
-                    }}
-                    columnSpacing={{ xs: 2 }}
-                  >
-                    <Grid item xs={3}>
-                      <Typography
-                        sx={{
-                          m: 2,
-                        }}
-                      >
-                        Airdrop Token Amount
-                      </Typography>
-                    </Grid>
-                    <Grid item xs={6}>
-                      <TextField
-                        fullWidth
-                        id="airdrop-token-amount"
-                        variant="outlined"
-                        required
-                        defaultValue={airdropTokenAmountValue}
-                        inputProps={{ style: { textAlign: "right" } }}
-                        onChange={(e: OnChangeEvent) =>
-                          setAirdropTokenAmountValue(e.target.value)
-                        }
-                        inputRef={airdropTokenAmountRef}
-                        error={airdropTokenAmountError}
-                        helperText={
-                          airdropTokenAmountError &&
-                          airdropTokenAmountRef?.current?.validationMessage
-                        }
-                      />
-                    </Grid>
-                  </Grid>
-                  <Grid
-                    container
-                    sx={{
-                      m: 2,
-                    }}
-                    columnSpacing={{ xs: 2 }}
-                  >
-                    <Grid item xs={3}>
-                      <Typography
-                        sx={{
-                          m: 2,
-                        }}
-                      >
-                        Snapshot Block Number
-                      </Typography>
-                    </Grid>
-                    <Grid item xs={6}>
-                      <TextField
-                        id="snapshot-block-number"
-                        variant="outlined"
-                        required
-                        defaultValue={snapshotBlockNumberValue}
-                        inputProps={{ style: { textAlign: "right" } }}
-                        sx={{
-                          width: 0.5,
-                        }}
-                        onChange={(e: OnChangeEvent) =>
-                          setSnapshotBlockNumberValue(e.target.value)
-                        }
-                        inputRef={snapshotBlockNumberRef}
-                        error={snapshotBlockNumberError}
-                        helperText={
-                          snapshotBlockNumberError &&
-                          snapshotBlockNumberRef?.current?.validationMessage
-                        }
-                      />
-                    </Grid>
-                  </Grid>
-                  <Grid
-                    container
-                    sx={{
-                      m: 2,
-                    }}
-                    columnSpacing={{ xs: 1 }}
-                  >
-                    <Grid item xs={3}>
-                      <Typography
-                        sx={{
-                          m: 2,
-                        }}
-                      >
-                        Snapshot Token Address
-                      </Typography>
-                    </Grid>
-                    <Grid item xs={9}>
-                      <Grid
-                        container
-                        sx={{
-                          m: 1,
-                        }}
-                        columnSpacing={{ xs: 1 }}
-                      >
-                        <Grid item xs={6}>
-                          <TextField
-                            fullWidth
-                            label="address"
-                            id="snapshot-token-address-1"
-                            variant="outlined"
-                            required
-                            defaultValue={snapshotTokenAddress1Value}
-                            onChange={(e: OnChangeEvent) =>
-                              setSnapshotTokenAddress1Value(e.target.value)
-                            }
-                            inputRef={snapshotTokenAddress1Ref}
-                            error={snapshotTokenAddress1Error}
-                            helperText={
-                              snapshotTokenAddress1Error &&
-                              snapshotTokenAddress1Ref?.current
-                                ?.validationMessage
-                            }
-                          />
-                        </Grid>
-                        <Grid item xs={2}>
-                          <TextField
-                            fullWidth
-                            label="coefficient"
-                            id="snapshot-token-coefficient-1"
-                            variant="outlined"
-                            required
-                            defaultValue={snapshotTokenCoefficient1Value}
-                            inputProps={{ style: { textAlign: "right" } }}
-                            onChange={(e: OnChangeEvent) =>
-                              setSnapshotTokenCoefficient1Value(e.target.value)
-                            }
-                            inputRef={snapshotTokenCoefficient1Ref}
-                            error={snapshotTokenCoefficient1Error}
-                            helperText={
-                              snapshotTokenCoefficient1Error &&
-                              snapshotTokenCoefficient1Ref?.current
-                                ?.validationMessage
-                            }
-                          />
-                        </Grid>
-                      </Grid>
-                      <Grid
-                        container
-                        sx={{
-                          m: 1,
-                        }}
-                        columnSpacing={{ xs: 1 }}
-                      >
-                        <Grid item xs={6}>
-                          <TextField
-                            fullWidth
-                            label="address"
-                            id="snapshot-token-address-2"
-                            variant="outlined"
-                            defaultValue={snapshotTokenAddress2Value}
-                            onChange={(e: OnChangeEvent) =>
-                              setSnapshotTokenAddress2Value(e.target.value)
-                            }
-                            inputRef={snapshotTokenAddress2Ref}
-                            error={snapshotTokenAddress2Error}
-                            helperText={
-                              snapshotTokenAddress2Error &&
-                              snapshotTokenAddress2Ref?.current
-                                ?.validationMessage
-                            }
-                          />
-                        </Grid>
-                        <Grid item xs={2}>
-                          <TextField
-                            fullWidth
-                            label="coefficient"
-                            id="snapshot-token-coefficient-2"
-                            variant="outlined"
-                            inputProps={{ style: { textAlign: "right" } }}
-                            defaultValue={snapshotTokenCoefficient2Value}
-                            onChange={(e: OnChangeEvent) =>
-                              setSnapshotTokenCoefficient2Value(e.target.value)
-                            }
-                            inputRef={snapshotTokenCoefficient2Ref}
-                            error={snapshotTokenCoefficient2Error}
-                            helperText={
-                              snapshotTokenCoefficient2Error &&
-                              snapshotTokenCoefficient2Ref?.current
-                                ?.validationMessage
-                            }
-                          />
-                        </Grid>
-                      </Grid>
-                    </Grid>
-                  </Grid>
-
                   <Typography
                     sx={{
                       m: 2,
                     }}
                   >
-                    Excluded Address List(Separated by line breaks)
+                    Airdrop List (Separated by line breaks)<br /><br />
+
+                    Enter one line at a time in the following order: <br />
+                    address,amount<br />
+                    Don't forget the comma(,) between the address and the amount!<br /><br />
+
+                    (Input Example)<br />
+                    0xaaa...zzz,100<br />
+                    0x111...999,200<br />
+                    ...<br />
+
                   </Typography>
                   <TextField
                     id="excluded-address-list"

--- a/packages/user-app/pages/create-merkle-tree-manual.tsx
+++ b/packages/user-app/pages/create-merkle-tree-manual.tsx
@@ -309,7 +309,7 @@ export default function CreateAirdrop() {
             if (!ok) { errorText = "address is not valid"; break; }
             ok &&= !Number.isNaN(result[1]);
             if (!ok) { errorText = "amount is only number"; break; }
-            ok &&= Number.isInteger(result[1]);
+            ok &&= Number.isInteger(Number(result[1]));
             if (!ok) { errorText = "amount is only integer"; break; }
           }
           else { errorText = "string does not contain a comma"; break; }
@@ -321,36 +321,6 @@ export default function CreateAirdrop() {
       }
       valid &&= ok;
     }
-
-    /*if (v) {
-      v.setCustomValidity("");
-      let ok = v.validity.valid;
-      if (v.value !== "") {
-        let spl = v.value.split(/\r?\n/);
-        spl.forEach(function (elm) {
-          ok &&= elm.includes(',');
-          if (ok) {
-            let result: string[] = elm.split(',');
-            ok &&= result.length === 2;
-            if (!ok) { errorText = "each line must contain two elements"; }
-            ok &&= result[0] !== "" && result[1] !== "";
-            if (!ok) { errorText = "address and/or amount is a blank character"; }
-            ok &&= ethers.utils.isAddress(result[0]);
-            if (!ok) { errorText = "address is not valid"; }
-            ok &&= !Number.isNaN(result[1]);
-            if (!ok) { errorText = "amount is only number"; }
-            ok &&= Number.isInteger(result[1]);
-            if (!ok) { errorText = "amount is only integer"; }
-          }
-          else { errorText = "string does not contain a comma"; }
-        });
-      }
-      setAirdropAddressAmountListError(!ok);
-      if (!ok) {
-        v.setCustomValidity(errorText);
-      }
-      valid &&= ok;
-    }*/
     return valid;
   };
 
@@ -406,7 +376,7 @@ export default function CreateAirdrop() {
     if (chainId == null) {
       return;
     }
-    let snapshotAmountDict: { [address: string]: BigNumber } = {};
+    /*let snapshotAmountDict: { [address: string]: BigNumber } = {};
     let resSnapshotAmount: { [address: string]: BigNumber } = {};
     let airdropAmountList: airdropListData[] = [];
     let ttlSnapshotAmount = BigNumber.from(0);
@@ -491,7 +461,7 @@ export default function CreateAirdrop() {
 
     setAirdropList(airdropAmountList);
 
-    setTtlAirdropAmount(ttlAirdropAmount.toString());
+    setTtlAirdropAmount(ttlAirdropAmount.toString());*/
 
     //the cese using api
     //useApiForWrittingFile(airdropAmountList, chainId);
@@ -536,7 +506,7 @@ export default function CreateAirdrop() {
                     Don't forget the comma(,) between the address and the amount!<br /><br />
 
                     (Input Example)<br />
-                    0xaaa...zzz,100<br />
+                    0x999...111,100<br />
                     0x111...999,200<br />
                     ...<br />
 

--- a/packages/user-app/pages/create-merkle-tree-snapshot.tsx
+++ b/packages/user-app/pages/create-merkle-tree-snapshot.tsx
@@ -383,11 +383,11 @@ export default function CreateAirdrop() {
   ): Promise<[{ [address: string]: BigNumber }, BigNumber]> => {
     let response = await fetch(
       "/api/token/holders?chainId=" +
-        BigNumber.from(chainId).toString() +
-        "&tokenAddress=" +
-        snapshotTokenAddress +
-        "&blockNumber=" +
-        snapshotBlockNumberValue
+      BigNumber.from(chainId).toString() +
+      "&tokenAddress=" +
+      snapshotTokenAddress +
+      "&blockNumber=" +
+      snapshotBlockNumberValue
     );
     let responseJson = (await response.json()) as holdersResponse;
     responseJson.data.map((data: { address: string; balance: string }) => {
@@ -407,7 +407,7 @@ export default function CreateAirdrop() {
     return [snapshotAmount, ttlSnapshotAmount];
   };
 
-  const useApiForWriteFile = async (airdropAmountList: airdropListData[]) => {
+  const useApiForWrittingFile = async (airdropAmountList: airdropListData[]) => {
     await fetch("/api/merkletree", {
       method: "POST",
       headers: {
@@ -443,18 +443,18 @@ export default function CreateAirdrop() {
     if (snapshotTokenAddress2Value !== "") {
       let response = await fetch(
         "/api/token/decimal?chainId=" +
-          BigNumber.from(chainId).toString() +
-          "&tokenAddress=" +
-          snapshotTokenAddress1Value
+        BigNumber.from(chainId).toString() +
+        "&tokenAddress=" +
+        snapshotTokenAddress1Value
       );
       let responseJson = (await response.json()) as decimalResponse;
       const decimals1 = responseJson.data;
 
       response = await fetch(
         "/api/token/decimal?chainId=" +
-          BigNumber.from(chainId).toString() +
-          "&tokenAddress=" +
-          snapshotTokenAddress2Value
+        BigNumber.from(chainId).toString() +
+        "&tokenAddress=" +
+        snapshotTokenAddress2Value
       );
       responseJson = (await response.json()) as decimalResponse;
       const decimals2 = responseJson.data;

--- a/packages/user-app/pages/index.tsx
+++ b/packages/user-app/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home() {
           </Button>
           <Button
             variant="contained"
-            href="/create-merkle-tree-snapshot"
+            href="/create-merkle-tree-manual"
             sx={{ p: 1, m: 1 }}
           >
             Create merkle-tree by manual


### PR DESCRIPTION
マニュアル版のマークルツリー作成ページを作りました！

入力欄は、airdrop-list(textarea)のみにしております。
桁数の多い文字列も1行に収まるようにレイアウトを調整しました。
入力欄の上にaddress,amountのフォーマットで入力してもらうよう注意書きを加えています。

入力は
 💡,が文字列に含まれているか判定
 含まれていれば,で文字列を分割した後
 💡,で分割したものの要素数が2つか判定
 💡,で分けたときに前半と後半の文字列がどちらも空文字でないか判定
 💡,で分けたときに前半の文字列がアドレスになっているか判定
 💡,で分けたときに後半の文字列が数値になっているか判定
 💡,で分けたときに後半の文字列が整数か判定
の手順でvalidateしております。

validate後、Airdrop Listの一覧と、トータルアマウントを表示し、
マークルツリーをダウンロードするボタンを表示しています。